### PR TITLE
Fix bug with decrementing progress bar, add set-able progress bar color fill

### DIFF
--- a/adafruit_progressbar.py
+++ b/adafruit_progressbar.py
@@ -118,7 +118,7 @@ class ProgressBar(displayio.TileGrid):
 
     @property
     def fill(self):
-        """The fill of the rectangle. Can be a hex value for a color or ``None`` for
+        """The fill of the progress bar. Can be a hex value for a color or ``None`` for
         transparent.
 
         """
@@ -126,7 +126,7 @@ class ProgressBar(displayio.TileGrid):
 
     @fill.setter
     def fill(self, color):
-        """Sets the fill of the rectangle. Can be a hex value for a color or ``None`` for
+        """Sets the fill of the progress bar. Can be a hex value for a color or ``None`` for
         transparent.
 
         """

--- a/adafruit_progressbar.py
+++ b/adafruit_progressbar.py
@@ -105,8 +105,8 @@ class ProgressBar(displayio.TileGrid):
         assert value <= 1.0, "Progress value may not be > 100%"
         assert isinstance(value, float), "Progress value must be a floating point value."
         if self._progress_val > value:
-            # bar colorized up to this position, unfill difference
-            for _w in range(int(value*self._width+2), self._width*self._progress_val-2):
+            # uncolorize range from width*value+margin to width-margin
+            for _w in range(int(value*self._width+2), self._width-2):
                 for _h in range(2, self._height-2):
                     self._bitmap[_w, _h] = 0
         else:
@@ -115,3 +115,24 @@ class ProgressBar(displayio.TileGrid):
                 for _h in range(2, self._height-2):
                     self._bitmap[_w, _h] = 2
         self._progress_val = value
+
+    @property
+    def fill(self):
+        """The fill of the rectangle. Can be a hex value for a color or ``None`` for
+        transparent.
+
+        """
+        return self._palette[0]
+
+    @fill.setter
+    def fill(self, color):
+        """Sets the fill of the rectangle. Can be a hex value for a color or ``None`` for
+        transparent.
+
+        """
+        if color is None:
+            self._palette[2] = 0
+            self._palette.make_transparent(0)
+        else:
+            self._palette[2] = color
+            self._palette.make_opaque(0)


### PR DESCRIPTION
* Progress bar does not leave graphical artifacts at `progress_val` while decrementing, writes to width-margin instead

* Adding a `fill` setter/getter method to allow someone to change the progress bar's color
  * Useful for applications where someone would want to display a "warning" color 

Tested on `Adafruit CircuitPython 5.0.0-beta.2 on 2019-12-20; Adafruit PyPortal with samd51j20`