### PR TITLE
Performance boost and simpletest update

### DIFF
--- a/adafruit_progressbar.py
+++ b/adafruit_progressbar.py
@@ -121,7 +121,6 @@ class ProgressBar(displayio.TileGrid):
             _prev_pixel = max(2, int(self._width * self._progress_val - 2))
             _new_pixel = max(int(self._width * value - 2), 2)
             for _w in range(_prev_pixel, _new_pixel - 1, -1):
-                print("w {}".format(_w))
                 for _h in range(2, self._height - 2):
                     self._bitmap[_w, _h] = 0
         else:

--- a/adafruit_progressbar.py
+++ b/adafruit_progressbar.py
@@ -117,12 +117,18 @@ class ProgressBar(displayio.TileGrid):
         ), "Progress value must be a floating point value."
         if self._progress_val > value:
             # uncolorize range from width*value+margin to width-margin
-            for _w in range(int(value * self._width + 2), self._width - 2):
+            # from right to left
+            _prev_pixel = max(2, int(self._width * self._progress_val - 2))
+            _new_pixel = max(int(self._width * value - 2), 2)
+            for _w in range(_prev_pixel, _new_pixel - 1, -1):
+                print("w {}".format(_w))
                 for _h in range(2, self._height - 2):
                     self._bitmap[_w, _h] = 0
         else:
-            # fully fill progress bar color
-            for _w in range(2, self._width * value - 2):
+            # fill from the previous x pixel to the new x pixel
+            _prev_pixel = max(2, int(self._width * self._progress_val - 3))
+            _new_pixel = min(int(self._width * value - 2), int(self._width * 1.0 - 3))
+            for _w in range(_prev_pixel, _new_pixel + 1):
                 for _h in range(2, self._height - 2):
                     self._bitmap[_w, _h] = 2
         self._progress_val = value

--- a/examples/progressbar_simpletest.py
+++ b/examples/progressbar_simpletest.py
@@ -27,10 +27,10 @@ splash.append(progress_bar)
 
 current_progress = 0.0
 while True:
-    while current_progress <= 1.0:
-        print("Progress: {}%".format(current_progress * 100))
-        progress_bar.progress = current_progress
-        current_progress += 0.05
-        if current_progress >= 1.0:
-            current_progress = 0.0
-        time.sleep(0.01)
+    for current_progress in range(0, 21):
+        print("Progress: {}%".format(current_progress * 0.05))
+        progress_bar.progress = current_progress * 0.05
+        time.sleep(0.02)
+    time.sleep(0.3)
+    progress_bar.progress = 0.0
+    time.sleep(0.3)

--- a/examples/progressbar_simpletest.py
+++ b/examples/progressbar_simpletest.py
@@ -27,9 +27,10 @@ splash.append(progress_bar)
 
 current_progress = 0.0
 while True:
-    for current_progress in range(0, 21):
-        print("Progress: {}%".format(current_progress * 0.05))
-        progress_bar.progress = current_progress * 0.05
+    # range end is exclusive so we need to use 1 bigger than max number that we want
+    for current_progress in range(0, 101, 5):
+        print("Progress: {}%".format(current_progress))
+        progress_bar.progress = current_progress / 100  # convert to decimal
         time.sleep(0.02)
     time.sleep(0.3)
     progress_bar.progress = 0.0

--- a/examples/progressbar_simpletest.py
+++ b/examples/progressbar_simpletest.py
@@ -28,10 +28,10 @@ splash.append(progress_bar)
 current_progress = 0.0
 while True:
     # range end is exclusive so we need to use 1 bigger than max number that we want
-    for current_progress in range(0, 101, 5):
+    for current_progress in range(0, 101, 1):
         print("Progress: {}%".format(current_progress))
         progress_bar.progress = current_progress / 100  # convert to decimal
-        time.sleep(0.02)
+        time.sleep(0.01)
     time.sleep(0.3)
     progress_bar.progress = 0.0
     time.sleep(0.3)


### PR DESCRIPTION
This addresses concerns raised in #7. 

The new progress drawing strategy will try to only change pixels that need it based on the new progress value and the previous progress value. 

It turned out that this library was suffering from the same issue going both directions. Running a loop backward through progresses like this:
```python
    for current_progress in range(20, -1, -1):
        print("Progress: {}%".format(current_progress * 0.05))
        progress_bar.progress = current_progress * 0.05
        time.sleep(0.01)
```
would result in a similar effect of the drawing slowing down as the progress approaches `0.0` I have implemented the new strategy in both cases of progress moving up and progress moving down. 

When the progress is moving down the library previously would fill the "empty" portion of the progress bar from left to right so it looked like it was moving "the wrong way" I modified the behavior to fill emptiness from right to left so the progress bar appears to visually "empty" itself in reverse as it gets drawn.

I made one other tweak to the simpletest example script to change it from adding floating point numbers to instead count by integers and multiple by a decimal to get the current progress. This lets us avoid a floating point precision issue that resulted in the progress sometimes getting set to things like `0.54999999` instead of `0.55`