### PR TITLE
Use vectorio instead of bitmap

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["displayio"]
+autodoc_mock_imports = ["displayio", "vectorio"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),


### PR DESCRIPTION
This changes the way the progress bar is drawn to use vectorio.Polygon objects. It results is less memory usage. 

Running on PyPortal the simpletest with a print mem_alloc() added I get these results: 

Current release mpy:
`mem_alloc 155232`

Version from this PR: 
`mem_alloc 15136`

Anecdotally it seems like erasing back to 0 progress is faster than before, but I can't be sure.