### PR TITLE
fix inital progress value drawing

### DIFF
--- a/adafruit_progressbar.py
+++ b/adafruit_progressbar.py
@@ -83,8 +83,9 @@ class ProgressBar(displayio.TileGrid):
         self._width = width
         self._height = height
 
-        self._progress_val = progress
+        self._progress_val = 0.0
         self.progress = self._progress_val
+        self.progress = progress
 
         # draw outline rectangle
         for _w in range(width):


### PR DESCRIPTION
This solves #12. 

With this change we will first set the progress value to `0.0` and then update it to the value that was passed to `init()` which allows it to get drawn correctly