### PR TITLE
Simpletest improvements

### DIFF
--- a/examples/progressbar_simpletest.py
+++ b/examples/progressbar_simpletest.py
@@ -8,7 +8,7 @@ splash = displayio.Group(max_size=10)
 board.DISPLAY.show(splash)
 
 # set progress bar width and height relative to board's display
-width = board.DISPLAY.width-40
+width = board.DISPLAY.width - 40
 height = 30
 
 x = board.DISPLAY.width // 2 - width // 2

--- a/examples/progressbar_simpletest.py
+++ b/examples/progressbar_simpletest.py
@@ -7,20 +7,15 @@ from adafruit_progressbar import ProgressBar
 splash = displayio.Group(max_size=10)
 board.DISPLAY.show(splash)
 
-# Make a background color fill
-color_bitmap = displayio.Bitmap(320, 240, 1)
-color_palette = displayio.Palette(1)
-color_palette[0] = 0x0
-bg_sprite = displayio.TileGrid(color_bitmap, x=0, y=0, pixel_shader=color_palette)
-splash.append(bg_sprite)
-##########################################################################
-
 # set progress bar width and height relative to board's display
-x = board.DISPLAY.width // 5
+width = board.DISPLAY.width-40
+height = 30
+
+x = board.DISPLAY.width // 2 - width // 2
 y = board.DISPLAY.height // 3
 
 # Create a new progress_bar object at (x, y)
-progress_bar = ProgressBar(x, y, 200, 30, 1.0)
+progress_bar = ProgressBar(x, y, width, height, 1.0)
 
 # Append progress_bar to the splash group
 splash.append(progress_bar)


### PR DESCRIPTION
These changes improve the simple test by making it more screen size independent. 

The background bmp has been removed. Most screens default to black background anyway so this was not visually doing anything in most cases I think. 

The width of the progress bar has been changed to be based on the screen width, that way this example will work on more different screen sizes and the progress bar will still fit on the screen. 

Changes tested on Wio Terminal, PyGamer, and CLUE.

This resolves #9 