### PR TITLE
make width and height public

### DIFF
--- a/adafruit_progressbar.py
+++ b/adafruit_progressbar.py
@@ -80,8 +80,8 @@ class ProgressBar(displayio.TileGrid):
         self._palette[1] = outline_color
         self._palette[2] = bar_color
 
-        self._width = width
-        self._height = height
+        self.width = width
+        self.height = height
 
         self._progress_val = 0.0
         self.progress = self._progress_val
@@ -119,17 +119,17 @@ class ProgressBar(displayio.TileGrid):
         if self._progress_val > value:
             # uncolorize range from width*value+margin to width-margin
             # from right to left
-            _prev_pixel = max(2, int(self._width * self._progress_val - 2))
-            _new_pixel = max(int(self._width * value - 2), 2)
+            _prev_pixel = max(2, int(self.width * self._progress_val - 2))
+            _new_pixel = max(int(self.width * value - 2), 2)
             for _w in range(_prev_pixel, _new_pixel - 1, -1):
-                for _h in range(2, self._height - 2):
+                for _h in range(2, self.height - 2):
                     self._bitmap[_w, _h] = 0
         else:
             # fill from the previous x pixel to the new x pixel
-            _prev_pixel = max(2, int(self._width * self._progress_val - 3))
-            _new_pixel = min(int(self._width * value - 2), int(self._width * 1.0 - 3))
+            _prev_pixel = max(2, int(self.width * self._progress_val - 3))
+            _new_pixel = min(int(self.width * value - 2), int(self.width * 1.0 - 3))
             for _w in range(_prev_pixel, _new_pixel + 1):
-                for _h in range(2, self._height - 2):
+                for _h in range(2, self.height - 2):
                     self._bitmap[_w, _h] = 2
         self._progress_val = value
 

--- a/adafruit_progressbar.py
+++ b/adafruit_progressbar.py
@@ -80,8 +80,8 @@ class ProgressBar(displayio.TileGrid):
         self._palette[1] = outline_color
         self._palette[2] = bar_color
 
-        self.width = width
-        self.height = height
+        self._width = width
+        self._height = height
 
         self._progress_val = 0.0
         self.progress = self._progress_val
@@ -140,6 +140,20 @@ class ProgressBar(displayio.TileGrid):
 
         """
         return self._palette[0]
+
+    @property
+    def width(self):
+        """The width of the progress bar. In pixels, includes the border.
+
+        """
+        return self._width
+
+    @property
+    def height(self):
+        """The height of the progress bar. In pixels, includes the border.
+
+        """
+        return self._height
 
     @fill.setter
     def fill(self, color):


### PR DESCRIPTION
Resolves #15 `width` and `height` properties exist without leading underscores with this change. 

Here is some sample code illustrating the usage of public `height` property to place a label below the progress bar: 
```python
import time
import board
import displayio
from adafruit_progressbar import ProgressBar
from adafruit_display_text import label
import terminalio

# Make the display context
splash = displayio.Group(max_size=10)
board.DISPLAY.show(splash)

# set progress bar width and height relative to board's display
width = board.DISPLAY.width - 40
height = 30

x = board.DISPLAY.width // 2 - width // 2
y = board.DISPLAY.height // 3

# Create a new progress_bar object at (x, y)
progress_bar = ProgressBar(x, y, width, height, 1.0)

# Append progress_bar to the splash group
splash.append(progress_bar)

# make a label
progress_label = label.Label(terminalio.FONT, text="Progress")
progress_label.anchor_point = (0.5, 0.0)

# put it just below the progress bar
progress_label.anchored_position = (board.DISPLAY.width//2, y + progress_bar.height)

splash.append(progress_label)

current_progress = 0.0
while True:
   pass # nothing needed for this example
```