### PR TITLE
Exposing API components in Readthedocs, adding examples to the Readthedocs API

### DIFF
--- a/adafruit_progressbar/__init__.py
+++ b/adafruit_progressbar/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-`progressbar_base`
+`adafruit_progressbar`
 ================================================================================
 
 Dynamic progress bar widget for CircuitPython displays

--- a/adafruit_progressbar/horizontalprogressbar.py
+++ b/adafruit_progressbar/horizontalprogressbar.py
@@ -57,7 +57,7 @@ class HorizontalProgressBar(ProgressBarBase):
     Using the diagrams below, the bar will fill in the following directions::
 
         --------------------------------
-        | Left-to-right   |  1-3 to 2-4 |
+        | Left-to-right  |  1-3 to 2-4 |
         --------------------------------
         | Right-to-left  |  2-4 to 1-3 |
         --------------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,6 +6,9 @@ API Definition
 .. If your library file(s) are nested in a directory (e.g. /adafruit_foo/foo.py)
 .. use this format as the module name: "adafruit_foo.foo"
 
+.. automodule:: adafruit_progressbar
+   :members:
+
 .. automodule:: adafruit_progressbar.horizontalprogressbar
    :members:
    :show-inheritance:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,53 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/progressbar_simpletest.py
     :caption: examples/progressbar_simpletest.py
     :linenos:
+
+
+Vertical Simple test
+--------------------
+
+Simple test to show a vertical Progress bar
+
+.. literalinclude:: ../examples/progressbar_vertical_simpletest.py
+    :caption: examples/progressbar_vertical_simpletest.py
+    :linenos:
+
+
+MatrixPortal Example
+--------------------
+
+Progressbar using the MatrixPortal
+
+.. literalinclude:: ../examples/progressbar_matrixportal.py
+    :caption: examples/examples/progressbar_matrixportal.py
+    :linenos:
+
+
+
+MagTag Example
+---------------
+
+Progressbar using the MagTag
+
+.. literalinclude:: ../examples/progressbar_magtag_simpletest.py
+    :caption: examples/progressbar_magtag_simpletest.py
+    :linenos:
+
+
+DisplayIO Blinka
+----------------
+
+Progressbar using DisplayIO in Blinka
+
+.. literalinclude:: ../examples/progressbar_displayio_blinka.py
+    :caption: examples/progressbar_displayio_blinka.py
+    :linenos:
+
+Combined ProgressBar
+--------------------
+
+Example showing both a Vertical and an Horizontal ProgressBar
+
+.. literalinclude:: ../examples/progressbar_combined.py
+    :caption: examples/progressbar_combined.py
+    :linenos:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,10 @@ Table of Contents
 .. toctree::
     :caption: Tutorials
 
+    ProgressBar Basics <https://learn.adafruit.com/magtag-progress-displays/progressbar-basics>
+
+    Adafruit MagTag COVID Vaccination Percent Tracker  <https://learn.adafruit.com/adafruit-magtag-covid-vaccination-percent-tracker>
+
 
 .. toctree::
     :caption: Related Products


### PR DESCRIPTION
Currently only adafruit_progressbar.ProgressBar is exposed in the Readhedocs API.
Adding Examples
Adding learning Guides examples