### PR TITLE
Remove max_size parameter

### DIFF
--- a/examples/progressbar_accelerometer.py
+++ b/examples/progressbar_accelerometer.py
@@ -137,7 +137,7 @@ fake__accel_data = [
     (3.476150, -4.812025, 7.421532),
 ]
 display = board.DISPLAY
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 color_bitmap = displayio.Bitmap(display.width, display.height, 1)

--- a/examples/progressbar_combined.py
+++ b/examples/progressbar_combined.py
@@ -14,7 +14,7 @@ from adafruit_progressbar.horizontalprogressbar import HorizontalProgressBar
 from adafruit_progressbar.verticalprogressbar import VerticalProgressBar
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 board.DISPLAY.show(splash)
 
 # set horizontal progress bar width and height relative to board's display

--- a/examples/progressbar_displayio_blinka.py
+++ b/examples/progressbar_displayio_blinka.py
@@ -22,7 +22,7 @@ from adafruit_progressbar.verticalprogressbar import (
 )
 
 display = PyGameDisplay(width=320, height=240, auto_refresh=False)
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(display.width, display.height, 1)

--- a/examples/progressbar_displayio_blinka_color_scale.py
+++ b/examples/progressbar_displayio_blinka_color_scale.py
@@ -23,7 +23,7 @@ from adafruit_progressbar.horizontalprogressbar import (
 )
 
 display = PyGameDisplay(width=320, height=240, auto_refresh=False)
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 # Setting up the grayscale values, You could use a different scale, and add more entries
@@ -70,7 +70,7 @@ horizontal_bar = HorizontalProgressBar(
 splash.append(horizontal_bar)
 
 # List of step values for the progress bar
-test_value_range_1 = [i for i in range(99)]
+test_value_range_1 = list(range(99))
 
 # Must check display.running in the main loop!
 while display.running:

--- a/examples/progressbar_magtag_simpletest.py
+++ b/examples/progressbar_magtag_simpletest.py
@@ -28,7 +28,7 @@ down_btn.direction = digitalio.Direction.INPUT
 down_btn.pull = digitalio.Pull.UP
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 # set progress bar width and height relative to board's display

--- a/examples/progressbar_matrixportal.py
+++ b/examples/progressbar_matrixportal.py
@@ -63,7 +63,7 @@ matrix = rgbmatrix.RGBMatrix(
 display = framebufferio.FramebufferDisplay(matrix)
 
 print("Adding display group")
-group = displayio.Group(max_size=5)  # Create a group to hold all our labels
+group = displayio.Group()  # Create a group to hold all our labels
 display.show(group)
 
 print("Creating progress bars and adding to group")

--- a/examples/progressbar_simpletest.py
+++ b/examples/progressbar_simpletest.py
@@ -10,7 +10,7 @@ from adafruit_progressbar.horizontalprogressbar import (
 )
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 board.DISPLAY.show(splash)
 
 # set progress bar width and height relative to board's display

--- a/examples/progressbar_vertical_simpletest.py
+++ b/examples/progressbar_vertical_simpletest.py
@@ -10,7 +10,7 @@ from adafruit_progressbar.verticalprogressbar import (
 )
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 board.DISPLAY.show(splash)
 
 # set progress bar width and height relative to board's display


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

Examples tested on a Pynt and Blinka where possible:
```
Adafruit CircuitPython 6.3.0 on 2021-06-01; Adafruit PyPortal with samd51j20
```
The MatrixPortal and MagTag examples were not tested as I don't have the hardware.