### PR TITLE
Fixed pylint errors

### DIFF
--- a/adafruit_progressbar/__init__.py
+++ b/adafruit_progressbar/__init__.py
@@ -490,12 +490,12 @@ class ProgressBarBase(displayio.TileGrid):
 
         return (float(value) - self.minimum) / (self.maximum - self.minimum)
 
-    @classmethod
-    def _get_value_sizes(cls, _old_ratio: float, _new_ratio: float) -> Tuple[int, int]:
+    # pylint: disable=no-self-use
+    def _get_value_sizes(self, _old_ratio: float, _new_ratio: float) -> Tuple[int, int]:
         return 0, 0
 
-    @classmethod
-    def _get_max_fill_size(cls) -> int:
+    # pylint: disable=no-self-use
+    def _get_max_fill_size(self) -> int:
         return 0
 
     def _get_ratios(
@@ -521,8 +521,8 @@ class ProgressBarBase(displayio.TileGrid):
     def _get_sizes_min_max(self) -> Tuple[int, int]:
         return 0, min(self.fill_width(), self.fill_height())
 
-    @classmethod
-    def _invert_fill_direction(cls) -> bool:
+    # pylint: disable=no-self-use
+    def _invert_fill_direction(self) -> bool:
         return False
 
     def _get_horizontal_fill(


### PR DESCRIPTION
Fixes the followng `pylint` errors:

```
 ************* Module adafruit_progressbar.horizontalprogressbar
Error: adafruit_progressbar/horizontalprogressbar.py:147:4: W0221: Number of parameters was 3 in 'ProgressBarBase._get_value_sizes' and is now 3 in overridden 'HorizontalProgressBar._get_value_sizes' method (arguments-differ)
Error: adafruit_progressbar/horizontalprogressbar.py:168:4: W0221: Number of parameters was 1 in 'ProgressBarBase._invert_fill_direction' and is now 1 in overridden 'HorizontalProgressBar._invert_fill_direction' method (arguments-differ)
Error: adafruit_progressbar/horizontalprogressbar.py:171:4: W0221: Number of parameters was 1 in 'ProgressBarBase._get_max_fill_size' and is now 1 in overridden 'HorizontalProgressBar._get_max_fill_size' method (arguments-differ)
```
