### PR TITLE
Add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ _build
 
 # Virtual environment-specific files
 .env
+.venv
 
 # MacOS-specific files
 *.DS_Store


### PR DESCRIPTION
Manual fix for library missed by adabot patch