### PR TITLE
margin_size seems to be int like in Vertical and Horizontal

### DIFF
--- a/adafruit_progressbar/__init__.py
+++ b/adafruit_progressbar/__init__.py
@@ -54,10 +54,10 @@ class ProgressBarBase(displayio.TileGrid):
                             be a hexadecimal value for color (0xEE7755).
                             Default: 0x000000 (Black)
     :type fill_color: int
-    :param margin_size: Specify whether a margin between the border of the widget and the bar
-                              representing the value should be visible or not.
-                              Default: True
-    :type margin_size: bool
+    :param margin_size: The thickness (in pixels) of the margin between the border and
+        the bar. If it is 1 or larger, will be filled in by the color of the
+        "fill_color" parameter.
+    :type margin_size: int
     :param value_range: Specify the range of allowed values for which the progress
                         should be displayed. When setting the "value" property,
                         this range is the one against which its progression will be determined.


### PR DESCRIPTION
The documentation is confusing.
Not sure when margin_size ever was a bool, but it looks like an int to me.

Took the description found in:

https://github.com/adafruit/Adafruit_CircuitPython_ProgressBar/blob/283822cd1a1c43031a460405d1f46be3d04ee28c/adafruit_progressbar/horizontalprogressbar.py#L101C1-L104C27

and in:

https://github.com/adafruit/Adafruit_CircuitPython_ProgressBar/blob/283822cd1a1c43031a460405d1f46be3d04ee28c/adafruit_progressbar/verticalprogressbar.py#L102C1-L106C1